### PR TITLE
Update FAQsCategories.ascx.cs

### DIFF
--- a/FAQsCategories.ascx.cs
+++ b/FAQsCategories.ascx.cs
@@ -239,13 +239,49 @@ namespace DotNetNuke.Modules.FAQs
 		#endregion
 
 		#region Private Methods
+		
+		internal class catInfo
+		{
+			// treeCategories fails with int? FaqCategoryParentId
+			// define a temp class that has no nullables
+			// set null ints to Null.NullInt
+			public int FaqCategoryParentId { get; set; }
+			public int FaqCategoryId { get; set; }
+			public int ModuleId { get; set; }
+			public string FaqCategoryName { get; set; }
+			public string FaqCategoryDescription { get; set; }
+			public int Level { get; set; }
+			public int ViewOrder { get; set; }
+
+        		public catInfo()
+        		{
+		        }
+    		}
 
 		private void BindData()
 		{
 			FAQsController FAQsController = new FAQsController();
             IEnumerable<CategoryInfo> cats = FAQsController.ListCategoriesHierarchical(ModuleId, false);
-
-            treeCategories.Nodes.Clear();
+			// treeCategories fails with int? FaqCategoryParentId
+			// define a temp class that has no nullables
+			// set null ints to Null.NullInt
+			ArrayList lst = new ArrayList();
+        		foreach (CategoryInfo cat in cats)
+        		{
+            			catInfo cinfo = new catInfo()
+            			{
+                			FaqCategoryParentId = cat.FaqCategoryParentId.HasValue ? cat.FaqCategoryParentId.Value : -1,
+                			FaqCategoryId = cat.FaqCategoryId,
+                			ModuleId = cat.ModuleId,
+                			FaqCategoryName = cat.FaqCategoryName,
+                			FaqCategoryDescription = cat.FaqCategoryDescription,
+                			Level = cat.Level,
+                			ViewOrder = cat.ViewOrder
+            			};
+            			lst.Add(cinfo);
+        		}
+        		
+            		treeCategories.Nodes.Clear();
 			treeCategories.DataTextField = "FaqCategoryName";
 			treeCategories.DataFieldID = "FaqCategoryId";
 			treeCategories.DataFieldParentID = "FaqCategoryParentId";


### PR DESCRIPTION
Categories can not be edited because treeCategories fails to correctly bind the data structure that has  a member of the class defined as a nullable.

A temporary fix is to define a class sepecifically for the treeCategories control that contains no referenced nullables.  Set null ints to Null.Nullint.
