### PR TITLE
Fixed an issue where the categories would not show when the settings where on Treeview mode

### DIFF
--- a/Components/CategoryInfoTreeNode.cs
+++ b/Components/CategoryInfoTreeNode.cs
@@ -1,0 +1,20 @@
+﻿namespace DotNetNuke.Modules.FAQs
+{
+    internal class CategoryInfoTreeNode
+    {
+        // treeCategories fails with int? FaqCategoryParentId
+        // define a temp class that has no nullables
+        // set null ints to Null.NullInt
+        public int FaqCategoryParentId { get; set; }
+        public int FaqCategoryId { get; set; }
+        public int ModuleId { get; set; }
+        public string FaqCategoryName { get; set; }
+        public string FaqCategoryDescription { get; set; }
+        public int Level { get; set; }
+        public int ViewOrder { get; set; }
+
+        public CategoryInfoTreeNode()
+        {
+        }
+    }
+}

--- a/Components/CategoryInfoTreeNodeExtensions.cs
+++ b/Components/CategoryInfoTreeNodeExtensions.cs
@@ -1,0 +1,19 @@
+﻿namespace DotNetNuke.Modules.FAQs
+{
+    internal static class CategoryInfoTreeNodeExtensions
+    {
+        internal static CategoryInfoTreeNode ToTreeNode(this CategoryInfo categoryInfo)
+        {
+            return new CategoryInfoTreeNode
+            {
+                FaqCategoryParentId = categoryInfo.FaqCategoryParentId.HasValue ? categoryInfo.FaqCategoryParentId.Value : 0,
+                FaqCategoryId = categoryInfo.FaqCategoryId,
+                ModuleId = categoryInfo.ModuleId,
+                FaqCategoryName = categoryInfo.FaqCategoryName,
+                FaqCategoryDescription = categoryInfo.FaqCategoryDescription,
+                Level = categoryInfo.Level,
+                ViewOrder = categoryInfo.ViewOrder
+            };
+        }
+    }
+}

--- a/DotNetNuke.FAQs.csproj
+++ b/DotNetNuke.FAQs.csproj
@@ -140,6 +140,8 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Components\CategoryInfo.cs" />
+    <Compile Include="Components\CategoryInfoTreeNode.cs" />
+    <Compile Include="Components\CategoryInfoTreeNodeExtensions.cs" />
     <Compile Include="Components\FAQsController.cs" />
     <Compile Include="Components\FAQsInfo.cs" />
     <Compile Include="Components\FAQsTokenReplace.cs" />

--- a/FAQs.ascx.cs
+++ b/FAQs.ascx.cs
@@ -383,11 +383,17 @@ namespace DotNetNuke.Modules.FAQs
                 CategoryInfo emptyCategory = new CategoryInfo();
                 emptyCategory.FaqCategoryId = -1;
                 emptyCategory.FaqCategoryName = Localization.GetString("EmptyCategory", LocalResourceFile);
+                emptyCategory.ModuleId = ModuleId;
+                emptyCategory.Level = 0;
+                emptyCategory.ViewOrder = 998;
 
                 //All Categories
                 CategoryInfo allCategories = new CategoryInfo();
                 allCategories.FaqCategoryId = -2;
                 allCategories.FaqCategoryName = Localization.GetString("AllCategory", LocalResourceFile);
+                allCategories.ModuleId = ModuleId;
+                allCategories.Level = 0;
+                allCategories.ViewOrder = 999;
 
                 IEnumerable<CategoryInfo> cats = FAQsController.ListCategoriesHierarchical(ModuleId, !ShowEmptyCategories);
 
@@ -414,10 +420,13 @@ namespace DotNetNuke.Modules.FAQs
                         {
                             categories.Add(cat);
                         }
-                        List<CategoryInfo> lst = new List<CategoryInfo>();
+                        // treeCategories fails with int? FaqCategoryParentId
+                        // define a temp class that has no nullables
+                        // set null ints to Null.NullInt
+                        ArrayList lst = new ArrayList();
                         foreach (CategoryInfo cat in categories)
                         {
-                            lst.Add(cat);
+                            lst.Add(cat.ToTreeNode());
                         }
                         treeCategories.DataTextField = "FaqCategoryName";
                         treeCategories.DataFieldID = "FaqCategoryId";

--- a/FAQsCategories.ascx.cs
+++ b/FAQsCategories.ascx.cs
@@ -239,25 +239,7 @@ namespace DotNetNuke.Modules.FAQs
         #endregion
 
         #region Private Methods
-
-        internal class catInfo
-        {
-            // treeCategories fails with int? FaqCategoryParentId
-            // define a temp class that has no nullables
-            // set null ints to Null.NullInt
-            public int FaqCategoryParentId { get; set; }
-            public int FaqCategoryId { get; set; }
-            public int ModuleId { get; set; }
-            public string FaqCategoryName { get; set; }
-            public string FaqCategoryDescription { get; set; }
-            public int Level { get; set; }
-            public int ViewOrder { get; set; }
-
-            public catInfo()
-            {
-            }
-        }
-
+        
         private void BindData()
         {
             FAQsController FAQsController = new FAQsController();
@@ -267,18 +249,8 @@ namespace DotNetNuke.Modules.FAQs
             // set null ints to Null.NullInt
             var lst = new List<catInfo>();
             foreach (CategoryInfo cat in cats)
-            {
-                catInfo cinfo = new catInfo()
-                {
-                    FaqCategoryParentId = cat.FaqCategoryParentId.HasValue ? cat.FaqCategoryParentId.Value : -1,
-                    FaqCategoryId = cat.FaqCategoryId,
-                    ModuleId = cat.ModuleId,
-                    FaqCategoryName = cat.FaqCategoryName,
-                    FaqCategoryDescription = cat.FaqCategoryDescription,
-                    Level = cat.Level,
-                    ViewOrder = cat.ViewOrder
-                };
-                lst.Add(cinfo);
+            {   
+                lst.Add(cat.ToTreeNode());
             }
 
             treeCategories.Nodes.Clear();

--- a/FAQsCategories.ascx.cs
+++ b/FAQsCategories.ascx.cs
@@ -247,7 +247,7 @@ namespace DotNetNuke.Modules.FAQs
             // treeCategories fails with int? FaqCategoryParentId
             // define a temp class that has no nullables
             // set null ints to Null.NullInt
-            var lst = new List<catInfo>();
+            var lst = new List<CategoryInfoTreeNode>();
             foreach (CategoryInfo cat in cats)
             {   
                 lst.Add(cat.ToTreeNode());

--- a/Installation/ReleaseNotes/Release.05.04.01.txt
+++ b/Installation/ReleaseNotes/Release.05.04.01.txt
@@ -3,6 +3,7 @@
 <p><strong>BUG FIXES</strong></p>
 <ul>
     <li>Fixed an issue where the categories editor would not show</li>
+	<li>Fixed an issue where the categories would not show when the settings where on Treeview mode</li>
 </ul>
 <p><strong>CHANGES</strong></p>
 <ul>


### PR DESCRIPTION
### Description of PR...
Fixed an issue where the categories would not show when the settings where on Treeview mode.

## Changes made
- RadTreeview needs an int for the level but the underlaying data had a nullable int which caused the issue

## PR Template Checklist

- [X] Fixes Bug
- [ ] Feature solution
- [ ] Other

Close #21 by reimplementing same code but manually mergin since part of that fix was already done in a different way and it would have caused a conflict
Closes #26
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/DNNCommunity/DNN.Faq/pull/27?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/DNNCommunity/DNN.Faq/pull/27'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>