### PR TITLE
Tricked DNNtc to create the manifest with supports Searchable

### DIFF
--- a/Components/FAQsController.cs
+++ b/Components/FAQsController.cs
@@ -44,7 +44,7 @@ namespace DotNetNuke.Modules.FAQs
     /// Main controller class for FAQs
     /// </summary>
     [DNNtc.BusinessControllerClass()]
-    public class FAQsController : ModuleSearchBase, IPortable
+    public class FAQsController : ModuleSearchBase, IPortable // : ISearchable <--- Do not remove this comment, it is required to make DNNtc packager to the old ISearchable is implemented to generate proper manifest
     {
         public const int MAX_DESCRIPTION_LENGTH = 100;
 

--- a/DotNetNuke.FAQs.csproj
+++ b/DotNetNuke.FAQs.csproj
@@ -199,6 +199,7 @@
     </None>
     <None Include="Installation\Uninstall.SqlDataProvider" />
     <None Include="Module.css" />
+    <Content Include="Installation\ReleaseNotes\Release.05.04.02.txt" />
     <Content Include="Installation\ReleaseNotes\Release.05.04.01.txt" />
     <Content Include="Installation\ReleaseNotes\Release.05.04.00.txt" />
     <Content Include="packages.config" />

--- a/Installation/DNN_FAQs.dnn
+++ b/Installation/DNN_FAQs.dnn
@@ -68,6 +68,7 @@
             <businessControllerClass>DotNetNuke.Modules.FAQs.FAQsController,DotNetNuke.Modules.FAQs</businessControllerClass>
             <supportedFeatures>
               <supportedFeature type="Portable" />
+              <supportedFeature type="Searchable" />
             </supportedFeatures>
             <moduleDefinitions>
               <moduleDefinition>

--- a/Installation/ReleaseNotes/Release.05.04.02.txt
+++ b/Installation/ReleaseNotes/Release.05.04.02.txt
@@ -2,7 +2,7 @@
 <p>FAQs 05.04.02 will work for any DNN version 8.0.4 and up and as been tested up to Dnn 9.2.2</p>
 <p><strong>BUG FIXES</strong></p>
 <ul>
-    <li>None</li>
+    <li>#34 Fixed an issue that prevented indexing the module content.</li>
 </ul>
 <p><strong>CHANGES</strong></p>
 <ul>


### PR DESCRIPTION
### Description of PR...
This module uses DNNtc to generate the manifest. DNNtc looks for ISearchable in order to identify if the module implements search. Being that this interface was replaced by ModuleSearchBase, the last release lost that information in the manifest.

## Changes made
- Added a comment with ISerchable to trick DNNtc into thinking that the old interface is implemented without affecting the actual code.
- Tested that on build the trick works and the manifest gets the correct information

## PR Template Checklist

- [x] Fixes Bug
- [ ] Feature solution
- [ ] Other

## Please mark which issue is solved
Close #34
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/DNNCommunity/DNN.Faq/pull/37?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/DNNCommunity/DNN.Faq/pull/37'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>