### PR TITLE
Fix missing images in docs

### DIFF
--- a/docs/Adding-FAQs.md
+++ b/docs/Adding-FAQs.md
@@ -1,17 +1,17 @@
 How to add a frequently asked question including an optional answer. Images can be added to answers, but movies and sound files cannot be added.
 
 1. Go to a FAQs module.
-1. Select **Edit** ![](/images/Edit-Pencil-on-Black.png?raw=true) > ![](/images/Edit-Pencil-on-Page.png?raw=true) **Add New FAQ** from the module actions menu. This opens the "Edit This FAQ Entry" page.
+1. Select **Edit** ![](/images/Edit-Pencil-on-Black.png) > ![](/images/Edit-Pencil-on-Page.png) **Add New FAQ** from the module actions menu. This opens the "Edit This FAQ Entry" page.
 1. In the **Question** text box, enter the question. A maximum of 400 characters is permitted.
 1. The following **optional** fields are provided:
 
     1. In the **Answer** text box, enter the answer.
     2. At **Category**, select a category from the drop down list. See "[Adding FAQ Categories](Adding-FAQ-Categories)"
     3. At **Hide FAQ**, check the check box to hide the FAQ from displaying. The FAQ will still be displayed to editors of this module, enabling them to edit or update the FAQ. This feature is useful if an FAQ is still unanswered, hiding it from being published until the answer has been completed.
-    4. At **Publish from Date**, click the **Calendar** ![](/images/Calendar-on-White.png?raw=true) button and select date this FAQ will be published.
+    4. At **Publish from Date**, click the **Calendar** ![](/images/Calendar-on-White.png) button and select date this FAQ will be published.
     5. At **Expire on Date**, click the **Calendar** button and select the date this FAQ will expire.
-![Adding FAQs](/images/Adding-FAQs-1.png?raw=true)
+![Adding FAQs](/images/Adding-FAQs-1.png)
 1. Click the **Update** button. The newly added FAQ is now displayed, unless it has been set as hidden.
-1. **Optional**. Click the **Down** ![](/images/Down-Arrow-Black.png?raw=true) arrow beside the Edit button to move it down the list of FAQs. Click the **Up** ![](/images/Up-Arrow-Black.png?raw=true) arrow beside the Edit button to move a FAQ entry up the list of FAQs.
+1. **Optional**. Click the **Down** ![](/images/Down-Arrow-Black.png) arrow beside the Edit button to move it down the list of FAQs. Click the **Up** ![](/images/Up-Arrow-Black.png) arrow beside the Edit button to move a FAQ entry up the list of FAQs.
   
-![](/images/Adding-FAQs-2.png?raw=true)
+![](/images/Adding-FAQs-2.png)

--- a/docs/Adding-FAQs.md
+++ b/docs/Adding-FAQs.md
@@ -1,17 +1,17 @@
 How to add a frequently asked question including an optional answer. Images can be added to answers, but movies and sound files cannot be added.
 
 1. Go to a FAQs module.
-1. Select **Edit** ![](/images/Edit-Pencil-on-Black.png) > ![](/images/Edit-Pencil-on-Page.png) **Add New FAQ** from the module actions menu. This opens the "Edit This FAQ Entry" page.
+1. Select **Edit** ![Edit](/images/Edit-Pencil-on-Black.png) > ![Edit](/images/Edit-Pencil-on-Page.png) **Add New FAQ** from the module actions menu. This opens the "Edit This FAQ Entry" page.
 1. In the **Question** text box, enter the question. A maximum of 400 characters is permitted.
 1. The following **optional** fields are provided:
 
     1. In the **Answer** text box, enter the answer.
     2. At **Category**, select a category from the drop down list. See "[Adding FAQ Categories](Adding-FAQ-Categories)"
     3. At **Hide FAQ**, check the check box to hide the FAQ from displaying. The FAQ will still be displayed to editors of this module, enabling them to edit or update the FAQ. This feature is useful if an FAQ is still unanswered, hiding it from being published until the answer has been completed.
-    4. At **Publish from Date**, click the **Calendar** ![](/images/Calendar-on-White.png) button and select date this FAQ will be published.
+    4. At **Publish from Date**, click the **Calendar** ![Calendar](/images/Calendar-on-White.png) button and select date this FAQ will be published.
     5. At **Expire on Date**, click the **Calendar** button and select the date this FAQ will expire.
 ![Adding FAQs](/images/Adding-FAQs-1.png)
 1. Click the **Update** button. The newly added FAQ is now displayed, unless it has been set as hidden.
-1. **Optional**. Click the **Down** ![](/images/Down-Arrow-Black.png) arrow beside the Edit button to move it down the list of FAQs. Click the **Up** ![](/images/Up-Arrow-Black.png) arrow beside the Edit button to move a FAQ entry up the list of FAQs.
+1. **Optional**. Click the **Down** ![Down](/images/Down-Arrow-Black.png) arrow beside the Edit button to move it down the list of FAQs. Click the **Up** ![Up](/images/Up-Arrow-Black.png) arrow beside the Edit button to move a FAQ entry up the list of FAQs.
   
-![](/images/Adding-FAQs-2.png)
+![Adding FAQs](/images/Adding-FAQs-2.png)

--- a/docs/Editing-FAQ-Templates.md
+++ b/docs/Editing-FAQ-Templates.md
@@ -1,7 +1,7 @@
 How to edit the layout templates for FAQ's. A template is provided for the answer, the question, as well as a loading template to be display while AJAX is loading the question. Nine different tokens can be added to these templates to display information such as the related category, the date the FAQ was created, number of times an item has been viewed, etc. A full list of tokens is listed on the Settings page.
 
 1. Go to a FAQs module.
-1. Select ![](/images/Settings-Gear-on-Black.png?raw=true) **Manage** > ![](/images/Settings-Gear-on-White.png?raw=true) **Settings** from the module actions menu.
+1. Select ![](/images/Settings-Gear-on-Black.png) **Manage** > ![](/images/Settings-Gear-on-White.png) **Settings** from the module actions menu.
 1. Select the FAQs Module's **Settings** tab.
 1. At **Question Template**, edit the default template for the question.
 1. At **Answer Template**, edit the default template for the answer.
@@ -10,6 +10,6 @@ How to edit the layout templates for FAQ's. A template is provided for the answe
 
 Note: In the below image, the Question Template has been modified to include the FAQ Index before the question and the background color of questions has been changed.
 
-![](/images/Editing-FAQ-Templates-1.png?raw=true)
+![](/images/Editing-FAQ-Templates-1.png)
 
 > Tip: To restore an original template, add a new module and copy and paste the template from the new module into the edited module.

--- a/docs/Editing-FAQ-Templates.md
+++ b/docs/Editing-FAQ-Templates.md
@@ -1,7 +1,7 @@
 How to edit the layout templates for FAQ's. A template is provided for the answer, the question, as well as a loading template to be display while AJAX is loading the question. Nine different tokens can be added to these templates to display information such as the related category, the date the FAQ was created, number of times an item has been viewed, etc. A full list of tokens is listed on the Settings page.
 
 1. Go to a FAQs module.
-1. Select ![](/images/Settings-Gear-on-Black.png) **Manage** > ![](/images/Settings-Gear-on-White.png) **Settings** from the module actions menu.
+1. Select ![Settings](/images/Settings-Gear-on-Black.png) **Manage** > ![Settings](/images/Settings-Gear-on-White.png) **Settings** from the module actions menu.
 1. Select the FAQs Module's **Settings** tab.
 1. At **Question Template**, edit the default template for the question.
 1. At **Answer Template**, edit the default template for the answer.
@@ -10,6 +10,6 @@ How to edit the layout templates for FAQ's. A template is provided for the answe
 
 Note: In the below image, the Question Template has been modified to include the FAQ Index before the question and the background color of questions has been changed.
 
-![](/images/Editing-FAQ-Templates-1.png)
+![Edit template](/images/Editing-FAQ-Templates-1.png)
 
 > Tip: To restore an original template, add a new module and copy and paste the template from the new module into the edited module.

--- a/docs/Managing-Category-Settings.md
+++ b/docs/Managing-Category-Settings.md
@@ -1,22 +1,22 @@
 How to optionally display categories on the FAQs module and choose the way categories are displayed. An "Unassigned" category will be displayed if one or more questions haven't been assigned to a category.
 
 1. Go to a FAQs module.
-1. Select ![](/images/Settings-Gear-on-Black.png?raw=true) **Manage** > ![](/images/Settings-Gear-on-White.png?raw=true) **Settings** from the module actions menu.
+1. Select ![](/images/Settings-Gear-on-Black.png) **Manage** > ![](/images/Settings-Gear-on-White.png) **Settings** from the module actions menu.
 1. Select the FAQs Module's **Settings** tab.
 1. At **Show Question Categories**, select from these options:
-      * Mark ![](/images/Checkbox-Checked.png?raw=true) the check box to display categories on the module. This will reveal these additional fields:
-        1. **Optional**. At **Show Tooltips**, mark ![](/images/Checkbox-Checked.png?raw=true) the check box to display the category description as a tooltip when a user hovers their mouse over the category name.
+      * Mark ![](/images/Checkbox-Checked.png) the check box to display categories on the module. This will reveal these additional fields:
+        1. **Optional**. At **Show Tooltips**, mark ![](/images/Checkbox-Checked.png) the check box to display the category description as a tooltip when a user hovers their mouse over the category name.
         1. At **Show Categories As**, choose to layout categories as a list, in a treeview or as a drop down list. 
-      * Unmark ![](/images/Checkbox-Unchecked.png?raw=true) the check box to hide categories.
-1. **Optional**. At **Show Empty Categories**, mark ![](/images/Checkbox-Checked.png?raw=true) the check box to display categories that have been created but don't have any FAQs.  
-![Managing Category Settings](/images/Managing-Category-Settings-1.png?raw=true)
+      * Unmark ![](/images/Checkbox-Unchecked.png) the check box to hide categories.
+1. **Optional**. At **Show Empty Categories**, mark ![](/images/Checkbox-Checked.png) the check box to display categories that have been created but don't have any FAQs.  
+![Managing Category Settings](/images/Managing-Category-Settings-1.png)
 1. Click the **Update** button.
 
-![Managing Category Settings](/images/Managing-Category-Settings-2.png?raw=true)  
+![Managing Category Settings](/images/Managing-Category-Settings-2.png)  
 _Categories displayed in a list with categories displayed as check boxes_
 
-![Managing Category Settings](/images/Managing-Category-Settings-3.png?raw=true)  
+![Managing Category Settings](/images/Managing-Category-Settings-3.png)  
 _Categories displayed in Treeview_
 
-![Managing Category Settings](/images/Managing-Category-Settings-4.png?raw=true)  
+![Managing Category Settings](/images/Managing-Category-Settings-4.png)  
 _Categories displayed in Dropdown view_ 

--- a/docs/Managing-Category-Settings.md
+++ b/docs/Managing-Category-Settings.md
@@ -1,14 +1,14 @@
 How to optionally display categories on the FAQs module and choose the way categories are displayed. An "Unassigned" category will be displayed if one or more questions haven't been assigned to a category.
 
 1. Go to a FAQs module.
-1. Select ![](/images/Settings-Gear-on-Black.png) **Manage** > ![](/images/Settings-Gear-on-White.png) **Settings** from the module actions menu.
+1. Select ![Gear](/images/Settings-Gear-on-Black.png) **Manage** > ![Gear](/images/Settings-Gear-on-White.png) **Settings** from the module actions menu.
 1. Select the FAQs Module's **Settings** tab.
 1. At **Show Question Categories**, select from these options:
-      * Mark ![](/images/Checkbox-Checked.png) the check box to display categories on the module. This will reveal these additional fields:
-        1. **Optional**. At **Show Tooltips**, mark ![](/images/Checkbox-Checked.png) the check box to display the category description as a tooltip when a user hovers their mouse over the category name.
+      * Mark ![Checkbox](/images/Checkbox-Checked.png) the check box to display categories on the module. This will reveal these additional fields:
+        1. **Optional**. At **Show Tooltips**, mark ![Checkbox](/images/Checkbox-Checked.png) the check box to display the category description as a tooltip when a user hovers their mouse over the category name.
         1. At **Show Categories As**, choose to layout categories as a list, in a treeview or as a drop down list. 
-      * Unmark ![](/images/Checkbox-Unchecked.png) the check box to hide categories.
-1. **Optional**. At **Show Empty Categories**, mark ![](/images/Checkbox-Checked.png) the check box to display categories that have been created but don't have any FAQs.  
+      * Unmark ![Checkbox](/images/Checkbox-Unchecked.png) the check box to hide categories.
+1. **Optional**. At **Show Empty Categories**, mark ![Checkbox](/images/Checkbox-Checked.png) the check box to display categories that have been created but don't have any FAQs.  
 ![Managing Category Settings](/images/Managing-Category-Settings-1.png)
 1. Click the **Update** button.
 

--- a/docs/Managing-FAQ-Categories.md
+++ b/docs/Managing-FAQ-Categories.md
@@ -1,9 +1,9 @@
 How to edit or delete an FAQ category. **Important**. A bug in FAQs 05.01.01 prevents categories from being edited or deleted.
 
 1. Go to a FAQs module.
-1. Select ![](/images/Edit-Pencil-on-Page.png?raw=true) **Manage Categories** from the module actions menu. This displays the Manage Categories page.
+1. Select ![](/images/Edit-Pencil-on-Page.png) **Manage Categories** from the module actions menu. This displays the Manage Categories page.
 1. In the category list, click on the name of the category to be edited.
-![](/images/Managing-FAQ-Categories-1.png?raw=true)
+![](/images/Managing-FAQ-Categories-1.png)
 1. The following options are available:
     * To edit the Parent Category, Category Name and/or Category Description, modify the details displayed to the right and then click the **Yes** button to confirm.
     * To change the order of categories, simply drag the selected category to new position. For Example, drag a category on top of another to make it a parent category.

--- a/docs/Managing-FAQ-Categories.md
+++ b/docs/Managing-FAQ-Categories.md
@@ -1,9 +1,9 @@
 How to edit or delete an FAQ category. **Important**. A bug in FAQs 05.01.01 prevents categories from being edited or deleted.
 
 1. Go to a FAQs module.
-1. Select ![](/images/Edit-Pencil-on-Page.png) **Manage Categories** from the module actions menu. This displays the Manage Categories page.
+1. Select ![Edit](/images/Edit-Pencil-on-Page.png) **Manage Categories** from the module actions menu. This displays the Manage Categories page.
 1. In the category list, click on the name of the category to be edited.
-![](/images/Managing-FAQ-Categories-1.png)
+![Manage faqs](/images/Managing-FAQ-Categories-1.png)
 1. The following options are available:
     * To edit the Parent Category, Category Name and/or Category Description, modify the details displayed to the right and then click the **Yes** button to confirm.
     * To change the order of categories, simply drag the selected category to new position. For Example, drag a category on top of another to make it a parent category.

--- a/docs/Managing-FAQs.md
+++ b/docs/Managing-FAQs.md
@@ -1,3 +1,3 @@
-Frequently asked question can be edited or deleted by clicking the **Edit** ![](/images/Edit-Pencil-on-White.png) button beside the FAQ and then either editing and updating the content, or deleting the content by clicking the **Delete** button. FAQs can also be reordered directly on the page by clicking the **Up** ![](/images/Up-Arrow-Black.png) or **Down** ![](/images/Down-Arrow-Black.png) button beside the Edit button.
+Frequently asked question can be edited or deleted by clicking the **Edit** ![Edit](/images/Edit-Pencil-on-White.png) button beside the FAQ and then either editing and updating the content, or deleting the content by clicking the **Delete** button. FAQs can also be reordered directly on the page by clicking the **Up** ![Up](/images/Up-Arrow-Black.png) or **Down** ![Down](/images/Down-Arrow-Black.png) button beside the Edit button.
 
-![](/images/Managing-FAQs-1.png)
+![Manage faqs](/images/Managing-FAQs-1.png)

--- a/docs/Managing-FAQs.md
+++ b/docs/Managing-FAQs.md
@@ -1,3 +1,3 @@
-Frequently asked question can be edited or deleted by clicking the **Edit** ![](/images/Edit-Pencil-on-White.png?raw=true) button beside the FAQ and then either editing and updating the content, or deleting the content by clicking the **Delete** button. FAQs can also be reordered directly on the page by clicking the **Up** ![](/images/Up-Arrow-Black.png?raw=true) or **Down** ![](/images/Down-Arrow-Black.png?raw=true) button beside the Edit button.
+Frequently asked question can be edited or deleted by clicking the **Edit** ![](/images/Edit-Pencil-on-White.png) button beside the FAQ and then either editing and updating the content, or deleting the content by clicking the **Delete** button. FAQs can also be reordered directly on the page by clicking the **Up** ![](/images/Up-Arrow-Black.png) or **Down** ![](/images/Down-Arrow-Black.png) button beside the Edit button.
 
-![](/images/Managing-FAQs-1.png?raw=true)
+![](/images/Managing-FAQs-1.png)

--- a/docs/Setting-the-Default-Sorting-Order-of-FAQ's.md
+++ b/docs/Setting-the-Default-Sorting-Order-of-FAQ's.md
@@ -1,7 +1,7 @@
 How to set the default sort order for FAQ's in the FAQs module.
 
 1. Go to a FAQs module.
-1. Select ![](/images/Settings-Gear-on-Black.png?raw=true) **Manage** > ![](/images/Settings-Gear-on-White.png?raw=true) **Settings** from the module actions menu.
+1. Select ![](/images/Settings-Gear-on-Black.png) **Manage** > ![](/images/Settings-Gear-on-White.png) **Settings** from the module actions menu.
 1. Select the FAQs Module Settings tab.
 1. At **Default Sorting**, select from the following sorting options:
      * **Predefined Order**: Select to sort FAQ's according to the order predefined by an Administrator or Page Editor. These users can set the order of FAQs using up and down arrows that are visible in edit mode.
@@ -11,9 +11,9 @@ How to set the default sort order for FAQ's in the FAQs module.
      * **Popularity (lowest first)**: Sorts FAQ's from the least popular to the most popular. Popularity is rated by the number of times the FAQ has been clicked.
      * **Creation Date (newest first)**: Select to sort FAQ's according to the date they were first created from newest to oldest.
      * **Creation Date (oldest first)**: Select to sort FAQ's according to the date they were first created from oldest to newest.
-1. At **User Can Sort**, mark ![](/images/Checkbox-Checked.png?raw=true) the check box to display the "Select Sort Order" field that allows users to change the default sort order      
-OR - unmark ![](/images/Checkbox-Unchecked.png?raw=true) the check box to disable user sorting ability.
-![](/images/Setting-the-Default-Sorting-Order-of-FAQs-1.png?raw=true)
+1. At **User Can Sort**, mark ![](/images/Checkbox-Checked.png) the check box to display the "Select Sort Order" field that allows users to change the default sort order      
+OR - unmark ![](/images/Checkbox-Unchecked.png) the check box to disable user sorting ability.
+![](/images/Setting-the-Default-Sorting-Order-of-FAQs-1.png)
 1. Click the **Update** button.
 
-![](/images/Setting-the-Default-Sorting-Order-of-FAQs-2.png?raw=true)
+![](/images/Setting-the-Default-Sorting-Order-of-FAQs-2.png)

--- a/docs/Setting-the-Default-Sorting-Order-of-FAQ's.md
+++ b/docs/Setting-the-Default-Sorting-Order-of-FAQ's.md
@@ -1,7 +1,7 @@
 How to set the default sort order for FAQ's in the FAQs module.
 
 1. Go to a FAQs module.
-1. Select ![](/images/Settings-Gear-on-Black.png) **Manage** > ![](/images/Settings-Gear-on-White.png) **Settings** from the module actions menu.
+1. Select ![Gear](/images/Settings-Gear-on-Black.png) **Manage** > ![Gear](/images/Settings-Gear-on-White.png) **Settings** from the module actions menu.
 1. Select the FAQs Module Settings tab.
 1. At **Default Sorting**, select from the following sorting options:
      * **Predefined Order**: Select to sort FAQ's according to the order predefined by an Administrator or Page Editor. These users can set the order of FAQs using up and down arrows that are visible in edit mode.
@@ -11,9 +11,9 @@ How to set the default sort order for FAQ's in the FAQs module.
      * **Popularity (lowest first)**: Sorts FAQ's from the least popular to the most popular. Popularity is rated by the number of times the FAQ has been clicked.
      * **Creation Date (newest first)**: Select to sort FAQ's according to the date they were first created from newest to oldest.
      * **Creation Date (oldest first)**: Select to sort FAQ's according to the date they were first created from oldest to newest.
-1. At **User Can Sort**, mark ![](/images/Checkbox-Checked.png) the check box to display the "Select Sort Order" field that allows users to change the default sort order      
-OR - unmark ![](/images/Checkbox-Unchecked.png) the check box to disable user sorting ability.
-![](/images/Setting-the-Default-Sorting-Order-of-FAQs-1.png)
+1. At **User Can Sort**, mark ![Checkbox](/images/Checkbox-Checked.png) the check box to display the "Select Sort Order" field that allows users to change the default sort order      
+OR - unmark ![Checkbox](/images/Checkbox-Unchecked.png) the check box to disable user sorting ability.
+![Sort](/images/Setting-the-Default-Sorting-Order-of-FAQs-1.png)
 1. Click the **Update** button.
 
-![](/images/Setting-the-Default-Sorting-Order-of-FAQs-2.png)
+![Sort](/images/Setting-the-Default-Sorting-Order-of-FAQs-2.png)

--- a/docs/Viewing-Answers.md
+++ b/docs/Viewing-Answers.md
@@ -2,5 +2,5 @@ How to view the answer to a frequently asked question.
 
 1. Go to a FAQs module.
 1. Click on the question or on the **Expand** button to display the answer beneath the question.
-![](/images/Viewing-Answers-1.png)
+![View answer](/images/Viewing-Answers-1.png)
 1. **Optional.** Click the question again to hide the answer.

--- a/docs/Viewing-Answers.md
+++ b/docs/Viewing-Answers.md
@@ -2,5 +2,5 @@ How to view the answer to a frequently asked question.
 
 1. Go to a FAQs module.
 1. Click on the question or on the **Expand** button to display the answer beneath the question.
-![](/images/Viewing-Answers-1.png?raw=true)
+![](/images/Viewing-Answers-1.png)
 1. **Optional.** Click the question again to hide the answer.

--- a/docs/_data/navigation.yml
+++ b/docs/_data/navigation.yml
@@ -11,12 +11,12 @@
 - title: Management
   sublinks:
   - title: Category Settings
-    url: Managing-Category-Settings.html
+    url: /Managing-Category-Settings.html
   - title: Managing FAQ Categories
-    url: Managing-FAQ-Categories.html
+    url: /Managing-FAQ-Categories.html
   - title: Managing FAQs
-    url: Managing-FAQs.html
+    url: /Managing-FAQs.html
   - title: Sorting Order
-    url: Setting-the-Default-Sorting-Order-of-FAQ's.html
+    url: /Setting-the-Default-Sorting-Order-of-FAQ's.html
 - title: Viewing Answers
-  url: Viewing-Answers.html
+  url: /Viewing-Answers.html


### PR DESCRIPTION
This should fix the missing images in the documentation website
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/DNNCommunity/DNN.Faq/pull/46?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/DNNCommunity/DNN.Faq/pull/46'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>