### PR TITLE
Fixed the CI Nuget Packages restore

### DIFF
--- a/build/Build.cs
+++ b/build/Build.cs
@@ -12,12 +12,14 @@ using Nuke.Common.ProjectModel;
 using Nuke.Common.Tooling;
 using Nuke.Common.Tools.DotNet;
 using Nuke.Common.Tools.MSBuild;
+using Nuke.Common.Tools.NuGet;
 using Nuke.Common.Utilities.Collections;
 using static Nuke.Common.EnvironmentInfo;
 using static Nuke.Common.IO.FileSystemTasks;
 using static Nuke.Common.IO.PathConstruction;
 using static Nuke.Common.Tools.DotNet.DotNetTasks;
 using static Nuke.Common.Tools.MSBuild.MSBuildTasks;
+using static Nuke.Common.Tools.NuGet.NuGetTasks;
 
 [CheckBuildProjectConfigurations]
 [GitHubActions(
@@ -74,8 +76,7 @@ class Build : NukeBuild
     Target Restore => _ => _
         .Executes(() =>
         {
-            DotNetRestore(s => s
-                .SetProjectFile(ModuleProject));
+            NuGetTasks.NuGet($"restore {ModuleProject} -PackagesDirectory packages");
         });
 
     Target Compile => _ => _

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Nuke.Common" Version="5.1.1" />
+    <PackageDownload Include="Nuget.CommandLine" Version="[5.8.1]" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The previous PR to migrate the build scripts to something more modern had an issue where Nuget packages would not restore in CI or command line builds. This PR sould fix that.